### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/acs4.py
+++ b/acs4.py
@@ -5,6 +5,7 @@ Entry points - call from command line, or see:
 queryresourceitems, upload, request and mint.
 
 """
+from __future__ import print_function
 
 import sys
 import re
@@ -298,7 +299,7 @@ def post(xml, server, port, password, api_path):
                              pretty_print=True,
                              encoding='utf-8')
     if debug:
-        print request
+        print(request)
     if dry_run:
         return None
 
@@ -314,7 +315,7 @@ def post(xml, server, port, password, api_path):
     conn.close()
 
     if debug:
-        print response_str
+        print(response_str)
 
     if response.tag == etree.QName(AdeptNS, 'error'):
         raise Acs4Exception(urllib.unquote(response.get('data')))
@@ -412,7 +413,7 @@ def make_hmac(password, el):
     if show_serialization:
         logger = debug_consumer()
         serialize_el(el, logger)
-        print logger.dump()
+        print(logger.dump())
 
     serialize_el(el, mac)
 
@@ -453,8 +454,7 @@ def serialize_el(el, consumer):
     # then by their names; sorting is done bytewise on UTF-8
     # representations."
 
-    keys = el.attrib.keys()
-    keys.sort()
+    keys = sorted(el.attrib.keys())
     for attname in keys:
         consumer.update(ATTRIBUTE)
         consume_str("") # TODO element namespace

--- a/acs4cmd.py
+++ b/acs4cmd.py
@@ -5,6 +5,7 @@ Entry points - call from command line, or see:
 queryresourceitems, upload, request and mint.
 
 """
+from __future__ import print_function
 
 import sys
 import optparse
@@ -146,7 +147,7 @@ python acs4cmd.py server request api request_type
                                          distributor=opts.distributor,
                                          port=opts.port)
         json.dump(result, sys.stdout, indent=4, sort_keys=True)
-        print
+        print()
 
     elif action == 'upload':
         fh = None
@@ -166,7 +167,7 @@ python acs4cmd.py server request api request_type
                              metadata=opts.metadata,
                              port=opts.port)
         json.dump(result, sys.stdout, indent=4, sort_keys=True)
-        print
+        print()
 
     elif action == 'request':
         request_types = ['get', 'count', 'create', 'delete', 'update']
@@ -202,7 +203,7 @@ python acs4cmd.py server request api request_type
                               permissions=opts.permissions,
                               port=opts.port)
         json.dump(result, sys.stdout, indent=4, sort_keys=True)
-        print
+        print()
 
     elif action == 'mint':
 
@@ -218,8 +219,8 @@ python acs4cmd.py server request api request_type
                                              port=opts.port)
         secret = distinfo['sharedSecret']
         name = distinfo['name']
-        print acs4.mint(server, secret, opts.resource, 'enterloan', name,
-                        port=opts.port)
+        print(acs4.mint(server, secret, opts.resource, 'enterloan', name,
+                        port=opts.port))
     parser.destroy()
 
 

--- a/bss.py
+++ b/bss.py
@@ -136,7 +136,7 @@ class acs4db():
                     user=user,
                     passwd=passwd,
                     )
-            except MySQLdb.OperationalError, e:
+            except MySQLdb.OperationalError as e:
                 if try_count > max_tries:
                     raise e
         self.conn.set_character_set('utf8')


### PR DESCRIPTION
* Use __print()__ function in both Python 2 and Python 3
    * __print()__ is a function in Python 3.
* Old style exceptions --> new style for Python 3
    * Python 3 treats old style exceptions as syntax errors but new style exceptions work as expected in both Python 2 and Python 3.